### PR TITLE
fix: typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Available languages 🌍
 - English 🇬🇧
-- Germany 🇩🇪
+- German 🇩🇪
 - Russian 🇷🇺
 - Persian 🇮🇷 (later)
 


### PR DESCRIPTION
"german" refers to the language, while "Germany" refers to the country