### PR TITLE
Fix time picker minutes overflow

### DIFF
--- a/core/ui/src/main/java/ru/aleshin/core/ui/views/TimePickerDialog.kt
+++ b/core/ui/src/main/java/ru/aleshin/core/ui/views/TimePickerDialog.kt
@@ -88,8 +88,9 @@ fun TimePickerDialog(
                     onDismissClick = onDismissRequest,
                     onCurrentTimeChoose = {
                         val currentTime = Calendar.getInstance()
+                        currentTime.add(Calendar.MINUTE, 1)
                         hours = currentTime.get(Calendar.HOUR_OF_DAY)
-                        minutes = currentTime.get(Calendar.MINUTE) + 1
+                        minutes = currentTime.get(Calendar.MINUTE)
                         if (!is24Format && (hours!! > 12 || hours == 0)) format = TimeFormat.PM
                     },
                     onConfirmClick = {


### PR DESCRIPTION
For example, if current time is 08:59, and if you try to set time to current time, it would overflow to 08:60. Which would be considered invalid and disable select button