### PR TITLE
Fix TimePickerDialog did not update AM/PM correctly

### DIFF
--- a/core/ui/src/main/java/ru/aleshin/core/ui/views/TimePickerDialog.kt
+++ b/core/ui/src/main/java/ru/aleshin/core/ui/views/TimePickerDialog.kt
@@ -91,7 +91,9 @@ fun TimePickerDialog(
                         currentTime.add(Calendar.MINUTE, 1)
                         hours = currentTime.get(Calendar.HOUR_OF_DAY)
                         minutes = currentTime.get(Calendar.MINUTE)
-                        if (!is24Format && (hours!! > 12 || hours == 0)) format = TimeFormat.PM
+                        if (!is24Format) {
+                            format = if (hours in 0..11) TimeFormat.AM else TimeFormat.PM
+                        }
                     },
                     onConfirmClick = {
                         val time = calendar.apply {


### PR DESCRIPTION
Bug was that if the format is set to PM, but the current time is AM, it didn't update the time format.